### PR TITLE
fix: open exit intent modal only when the mouse leaves the top of the page

### DIFF
--- a/website/components/ExitIntentModal.tsx
+++ b/website/components/ExitIntentModal.tsx
@@ -25,9 +25,12 @@ const ExitIntent = () => {
   const [isMouseOut, setMouseOut] = useState(false)
   const [email, setEmail] = useState("")
 
-  const mouseOut = () => {
-    setMouseOut(true)
-    document.removeEventListener("mouseleave", mouseOut)
+  const mouseOut = (event) => {
+    if (event.clientY < 1) 
+      {
+      setMouseOut(true)
+      document.removeEventListener("mouseleave", mouseOut)
+    }
   }
 
   useEffect(() => {

--- a/website/components/ExitIntentModal.tsx
+++ b/website/components/ExitIntentModal.tsx
@@ -73,7 +73,7 @@ const ExitIntent = () => {
                 value="Join now!"
                 name="subscribe"
                 id="mc-embedded-subscribe"
-                style={{ fontSize: "16px;" }}
+                style={{ fontSize: "16px" }}
                 className="button"
               />
             </div>


### PR DESCRIPTION
- [ ] Open exit intent modal on `mouseleave` and when `clientY` is lower than `1`

- [ ] Removal of accidental semicolon in `fontSize`